### PR TITLE
Switch from using `fromCharCode` to using `fromCodePoint`

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -660,7 +660,7 @@
                 document.getElementById('name').innerHTML = icon.name;
             };
             i.onmouseup = function () {
-                copyText(String.fromCharCode(parseInt(icon.hex, 16)));
+                copyText(String.fromCodePoint(parseInt(icon.hex, 16)));
             };
             code.onmouseup = function () {
                 copyText(icon.hex);


### PR DESCRIPTION
Reenabled copying and pasting of icons by clicking on the glyph.

Closes https://github.com/Templarian/MaterialDesign/issues/4037.