### PR TITLE
Add error console output for webfont errors.

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -348,5 +348,6 @@ webfont(getConfig())
   return result;
 })
 .catch(error => {
+  console.error(error);
   throw error;
 });


### PR DESCRIPTION
It's quite hard to understand what's happening when `webfont` throws errors.
This PR adds `console.error` for those.

### Original output example
```
Generating from 1 icons:
error Command failed with exit code 1.
```

### With this PR
```
Generating from 1 icons:
Error: Files glob patterns specified did not match any files
    at _default (xxxx/node_modules/webfont/dist/standalone.js:209:11)
```