### PR TITLE
Fix path to SVG folder

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -311,7 +311,7 @@ function getConfig() {
     version
   } = fontBuildJson;
   const config = {
-    files: 'svg/*.svg',
+    files: `${svgFolder}/*.svg`,
     fontName,
     formats: formats,
     fontHeight: 512,


### PR DESCRIPTION
Path to svg folder is hardcoded and dont make use of the `svgFolder` CLI arguement. Results in error when the CLI tool is ran from a different root path.